### PR TITLE
Fix test for shutil.disk_usage

### DIFF
--- a/aioshutil/__init__.py
+++ b/aioshutil/__init__.py
@@ -75,6 +75,6 @@ get_terminal_size = sync_to_async(shutil.get_terminal_size)
 SameFileError = shutil.SameFileError
 
 
-if hasattr(shutil, "statvfs"):  # pragma: no cover
+if "disk_usage" in shutil.__all__:  # pragma: no cover
     __all__.append("disk_usage")
     disk_usage = sync_to_async(shutil.disk_usage)


### PR DESCRIPTION
Replace the test for `statvfs` with a test for the shutil module exporting `disk_usage`. The test for `statvfs` always failed because there is no `shutil.statvfs` function, only `os.statvfs` (but only on Linux systems).