### PR TITLE
Upgrade black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: fix-encoding-pragma
       - id: requirements-txt-fixer
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.8.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
Black 20.8b1 broke when click removed an internal function it relied on.
Switching to the latest stable release fixes this.
