### PR TITLE
Switched to `math.isclose` to compare file timestamps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,14 +10,14 @@ repos:
       - id: fix-encoding-pragma
       - id: requirements-txt-fixer
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pre-commit
 pytest
 pytest-asyncio
 pytest-cov
-pytest-mypy-plugins

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,5 +10,3 @@ ignore =
     W605
 [isort]
 profile = black
-[mypy]
-python_version = 3.8

--- a/tests/test_aioshutil.py
+++ b/tests/test_aioshutil.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import math
 import os
 import stat
 from pathlib import Path
@@ -36,9 +37,10 @@ async def test_copystat(tmp_path: Path):
     tmp_path.joinpath("temp1.txt").write_text("Hello World!", encoding="utf-8")
     tmp_path.joinpath("temp1.txt").chmod(stat.S_IEXEC)
     await aioshutil.copystat(tmp_path / "temp.txt", tmp_path / "temp1.txt")
-    assert (
-        tmp_path.joinpath("temp1.txt").stat().st_atime
-        == tmp_path.joinpath("temp.txt").stat().st_atime
+    assert math.isclose(
+        tmp_path.joinpath("temp1.txt").stat().st_atime,
+        tmp_path.joinpath("temp.txt").stat().st_atime,
+        rel_tol=1e-6,
     )
     assert (
         tmp_path.joinpath("temp1.txt").stat().st_mode
@@ -64,9 +66,10 @@ async def test_copy2(tmp_path: Path):
         tmp_path.joinpath("temp.txt").stat().st_mode | stat.S_IEXEC
     )
     await aioshutil.copy2(tmp_path.joinpath("temp.txt"), tmp_path.joinpath("temp1.txt"))
-    assert (
-        tmp_path.joinpath("temp1.txt").stat().st_atime
-        == tmp_path.joinpath("temp.txt").stat().st_atime
+    assert math.isclose(
+        tmp_path.joinpath("temp1.txt").stat().st_atime,
+        tmp_path.joinpath("temp.txt").stat().st_atime,
+        rel_tol=1e-6,
     )
     assert (
         tmp_path.joinpath("temp1.txt").stat().st_mode


### PR DESCRIPTION
Access and/or modification times may be truncated in destination files when copying stats (or the entire file).
* Fix for #9 