### PR TITLE
Remove deprecated ExecError alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,4 @@ await rmtree("/tmp")
 
 - `Error`
 - `SpecialFileError`
-- `ExecError`
 - `SameFileError`

--- a/aioshutil/__init__.py
+++ b/aioshutil/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
     "rmtree",
     "Error",
     "SpecialFileError",
-    "ExecError",
     "make_archive",
     "get_archive_formats",
     "register_archive_format",
@@ -201,7 +200,6 @@ copytree = sync_to_async(shutil.copytree)
 move = sync_to_async(shutil.move)
 Error = shutil.Error
 SpecialFileError = shutil.SpecialFileError
-ExecError = shutil.ExecError
 make_archive = sync_to_async(shutil.make_archive)
 get_archive_formats = sync_to_async(shutil.get_archive_formats)
 register_archive_format = sync_to_async(shutil.register_archive_format)  # type: ignore # noqa: F811


### PR DESCRIPTION
> The `ExecError` exception has been deprecated since Python 3.14. It has not been used by any function in shutil since Python 3.4, and is now an alias of [RuntimeError](https://docs.python.org/3/library/exceptions.html#RuntimeError).

https://docs.python.org/3/deprecations/index.html#pending-removal-in-python-3-16